### PR TITLE
Use size from icon theme if none is given

### DIFF
--- a/lib/heroicons.dart
+++ b/lib/heroicons.dart
@@ -37,8 +37,8 @@ class HeroIcon extends StatelessWidget {
     return SvgPicture.asset(
       '$path.svg',
       color: color ?? IconTheme.of(context).color,
-      width: size,
-      height: size,
+      width: size ?? IconTheme.of(context).size,
+      height: size ?? IconTheme.of(context).size,
       alignment: Alignment.center,
     );
   }


### PR DESCRIPTION
Makes the widget behave more like the Icon widget from the material widgets by defaulting to the size from the closest IconTheme ancestor if no size is given to the constructor.