### PR TITLE
path version downgrade

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^1.1.0
-  path: ^1.8.2
+  path: ^1.8.1
 
 dev_dependencies:
   code_builder: ^4.1.0


### PR DESCRIPTION
Because every version of flutter_test from sdk depends on path 1.8.1 and heroicons >=0.6.0 depends on path ^1.8.2, flutter_test from sdk is incompatible with heroicons >=0.6.0.

Minor or major version; should not be changed in the absence of breaking changes.